### PR TITLE
fix:  Error: Cannot find module 'eslint/lib/formatters/stylish'

### DIFF
--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -79,8 +79,6 @@ module.exports = function (ctx) {
           loader: 'eslint-loader',
           exclude: /node_modules/,
           options: {
-            cache: true,
-            failOnError: true,
             formatter: require('eslint').CLIEngine.getFormatter('stylish')
           }
         })


### PR DESCRIPTION
If anyone upgrades to eslint ^6.0.0 the quasar build breaks with `Module build failed: Error: Cannot find module 'eslint/lib/formatters/stylish'`
It's because they changed the following path:
```
eslint 5.x: eslint/lib/formatters/stylish
eslint 6.x: eslint/lib/cli-engine/formatters/stylish
```
This works for loaders that use the `CLIEngine.getFormatter` API, but eslint-loader did not.
Fortunately, you can manually fix this by making the loader look like this:
```js
      extendWebpack (cfg) {
        cfg.module.rules.push({
          enforce: 'pre',
          test: /\.(js|vue)$/,
          loader: 'eslint-loader',
          exclude: /node_modules/,
          options: {
            cache: true,
            failOnError: true,
            formatter: require('eslint').CLIEngine.getFormatter('stylish')
          }
        })
      }
```
Notice the options. I have run and verified this. Also works for version < 6
