### PR TITLE
fix(cli, eslint): Do not disable console calls in node

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -82,8 +82,6 @@ module.exports = {
     {{/if_eq}}
     'prefer-promise-reject-errors': 'off',
 
-    // allow console.log during development only
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }


### PR DESCRIPTION
Console calls should not be disabled in node (https://eslint.org/docs/rules/no-console#when-not-to-use-it)

Closes https://github.com/quasarframework/quasar/issues/5529

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No
