### PR TITLE
feat: Provided default values explicitly to quasar.conf.js template

### DIFF
--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -35,8 +35,8 @@ module.exports = function (ctx) {
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework
     framework: {
-      // iconSet: 'ionicons-v4', // Quasar icon set
-      // lang: 'de', // Quasar language pack
+      iconSet: 'material-icons', // Quasar icon set
+      lang: 'en-us', // Quasar language pack
 
       // Possible values for "all":
       // * 'auto' - Auto-import needed Quasar components & directives
@@ -80,10 +80,10 @@ module.exports = function (ctx) {
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-build
     build: {
       scopeHoisting: true,
-      // vueRouterMode: 'history',
-      // showProgress: false,
-      // gzip: true,
-      // analyze: true,
+      vueRouterMode: 'hash', // available values: 'hash', 'history', 'abstract'
+      showProgress: true,
+      gzip: false,
+      analyze: false,
       // preloadChunks: false,
       // extractCSS: false,
 
@@ -105,8 +105,8 @@ module.exports = function (ctx) {
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer
     devServer: {
-      // https: true,
-      // port: 8080,
+      https: false,
+      port: 8080,
       open: true // opens browser window automatically
     },
 
@@ -121,12 +121,12 @@ module.exports = function (ctx) {
 
     // https://quasar.dev/quasar-cli/developing-pwa/configuring-pwa
     pwa: {
-      // workboxPluginMode: 'InjectManifest',
-      // workboxOptions: {}, // only for NON InjectManifest
+      workboxPluginMode: 'GenerateSW', // 'GenerateSW' or 'InjectManifest'
+      workboxOptions: {}, // only for GenerateSW
       manifest: {
-        // name: '{{ productName }}',
-        // short_name: '{{ productName }}',
-        // description: '{{ description }}',
+        name: '{{ productName }}',
+        short_name: '{{ productName }}',
+        description: '{{ description }}',
         display: 'standalone',
         orientation: 'portrait',
         background_color: '#ffffff',
@@ -163,19 +163,19 @@ module.exports = function (ctx) {
 
     // https://quasar.dev/quasar-cli/developing-cordova-apps/configuring-cordova
     cordova: {
-      // id: '{{ cordovaId }}',
+      id: '{{ cordovaId }}',
       // noIosLegacyBuildFlag: true, // uncomment only if you know what you are doing
     },
 
 
     // https://quasar.dev/quasar-cli/developing-capacitor-apps/configuring-capacitor
     capacitor: {
-      // hideSplashscreen: false
+      hideSplashscreen: true
     },
 
     // https://quasar.dev/quasar-cli/developing-electron-apps/configuring-electron
     electron: {
-      // bundler: 'builder', // or 'packager'
+      bundler: 'packager', // 'packager' or 'builder'
 
       packager: {
         // https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#options
@@ -193,7 +193,7 @@ module.exports = function (ctx) {
       builder: {
         // https://www.electron.build/configuration/configuration
 
-        // appId: '{{ name }}'
+        appId: '{{ name }}'
       },
 
       // keep in sync with /src-electron/main-process/electron-main

--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -84,6 +84,7 @@ module.exports = function (ctx) {
       showProgress: true,
       gzip: false,
       analyze: false,
+      // Options below are automatically set depending on the env, set them if you want to override
       // preloadChunks: false,
       // extractCSS: false,
 

--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -77,10 +77,10 @@ module.exports = function (ctx) {
     // https://quasar.dev/quasar-cli/cli-documentation/supporting-ie
     supportIE: {{#if preset.ie}}true{{else}}false{{/if}},
 
-    // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-build
+    // Full list of options: https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-build
     build: {
       scopeHoisting: true,
-      vueRouterMode: 'hash', // available values: 'hash', 'history', 'abstract'
+      vueRouterMode: 'hash', // available values: 'hash', 'history'
       showProgress: true,
       gzip: false,
       analyze: false,
@@ -104,7 +104,7 @@ module.exports = function (ctx) {
       }
     },
 
-    // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer
+    // Full list of options: https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer
     devServer: {
       https: false,
       port: 8080,
@@ -162,19 +162,19 @@ module.exports = function (ctx) {
       }
     },
 
-    // https://quasar.dev/quasar-cli/developing-cordova-apps/configuring-cordova
+    // Full list of options: https://quasar.dev/quasar-cli/developing-cordova-apps/configuring-cordova
     cordova: {
       id: '{{ cordovaId }}',
       // noIosLegacyBuildFlag: true, // uncomment only if you know what you are doing
     },
 
 
-    // https://quasar.dev/quasar-cli/developing-capacitor-apps/configuring-capacitor
+    // Full list of options: https://quasar.dev/quasar-cli/developing-capacitor-apps/configuring-capacitor
     capacitor: {
       hideSplashscreen: true
     },
 
-    // https://quasar.dev/quasar-cli/developing-electron-apps/configuring-electron
+    // Full list of options: https://quasar.dev/quasar-cli/developing-electron-apps/configuring-electron
     electron: {
       bundler: 'packager', // 'packager' or 'builder'
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
Previously it was like some magic going on with options and values, and the user can't be sure what is the actual value. Uncommented some options and provided actual default values for them. I also improved some clarification comments and added more of them. Personally I was digging the source and losing lots of time to figure out what is the value of an option when I needed it. So I hope these changes save some time for others.

I used mostly [quasar/app/lib/quasar-config.js](https://github.com/quasarframework/quasar/blob/573e43b460e50021f0857eb506c2294b15ed9499/app/lib/quasar-config.js) for determining default values.