### PR TITLE
feat(a11y): Improved Contrast and Color Accessibility

### DIFF
--- a/template/src/css/quasar.variables.sass
+++ b/template/src/css/quasar.variables.sass
@@ -12,7 +12,7 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$primary   : #027BE3
+$primary   : #1976D2
 $secondary : #26A69A
 $accent    : #9C27B0
 

--- a/template/src/css/quasar.variables.scss
+++ b/template/src/css/quasar.variables.scss
@@ -12,7 +12,7 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$primary   : #027BE3;
+$primary   : #1976D2;
 $secondary : #26A69A;
 $accent    : #9C27B0;
 

--- a/template/src/css/quasar.variables.styl
+++ b/template/src/css/quasar.variables.styl
@@ -12,7 +12,7 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$primary   = #027BE3
+$primary   = #1976D2
 $secondary = #26A69A
 $accent    = #9C27B0
 

--- a/template/src/layouts/MyLayout.vue
+++ b/template/src/layouts/MyLayout.vue
@@ -23,10 +23,10 @@
       v-model="leftDrawerOpen"
       show-if-above
       bordered
-      content-class="bg-grey-2"
+      content-class="bg-grey-1"
     >
       <q-list>
-        <q-item-label header>Essential Links</q-item-label>
+        <q-item-label header class="text-grey-8">Essential Links</q-item-label>
         <q-item clickable tag="a" target="_blank" href="https://quasar.dev">
           <q-item-section avatar>
             <q-icon name="school" />


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
I used [Google Lighthouse](https://developers.google.com/web/tools/lighthouse) for auditing, then pretty much done some guess-work and used [Contrast Checker](https://webaim.org/resources/contrastchecker/).
I also changed the primary color to darker blue of the Quasar logo because it both looks a bit more harmonic and improves the a11y.
The only thing left to improve the a11y score to 100 is quasarframework/rfcs#3, at least in the `quasar-starter-kit`.

**Lighthouse Audit Results**
<details>
  <summary>Before:</summary>

  ![image](https://user-images.githubusercontent.com/6266078/73605920-9803bb80-45b5-11ea-8172-8094bee36c07.png)
</details>

<details>
  <summary>After:</summary>
  
  ![image](https://user-images.githubusercontent.com/6266078/73605932-bd90c500-45b5-11ea-8537-39c3acc2a5e7.png)
</details>

To read about this topic: [Contrast and Color Accessibility](https://webaim.org/articles/contrast/)