### PR TITLE
feat: Added Webpack alias support for VS Code

### DIFF
--- a/template/jsconfig.json
+++ b/template/jsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"],
+      "app/*": ["*"],
+      "components/*": ["src/components/*"],
+      "layouts/*": ["src/boot/*"],
+      "pages/*": ["src/boot/*"],
+      "assets/*": ["src/boot/*"],
+      "boot/*": ["src/boot/*"],
+      "vue$": ["node_modules/vue/dist/vue.esm.js"]
+    }
+  },
+  "exclude": [
+    "dist",
+    ".quasar",
+    "node_modules"
+  ]
+}

--- a/template/jsconfig.json
+++ b/template/jsconfig.json
@@ -5,9 +5,9 @@
       "src/*": ["src/*"],
       "app/*": ["*"],
       "components/*": ["src/components/*"],
-      "layouts/*": ["src/boot/*"],
-      "pages/*": ["src/boot/*"],
-      "assets/*": ["src/boot/*"],
+      "layouts/*": ["src/layouts/*"],
+      "pages/*": ["src/pages/*"],
+      "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"],
       "vue$": ["node_modules/vue/dist/vue.esm.js"]
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Feature

**Does this PR introduce a breaking change?**
- No

**The PR fulfills these requirements:**
- It's submitted to the `dev` branch and **not** the `master` branch

**Other information:**
VS Code IntelliSense doesn't work with resolve Webpack aliases, this PR adds `jsconfig.json` file to the template. The file is filled with the available aliases that are [stated in the docs](https://quasar.dev/quasar-cli/cli-documentation/handling-webpack#Webpack-Aliases).