### PR TITLE
fix: Updated the link for eslint-plugin-vue's documentation

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     {{/if_eq}}
     // Uncomment any of the lines below to choose desired strictness,
     // but leave only one uncommented!
-    // See https://vuejs.github.io/eslint-plugin-vue/rules/#available-rules
+    // See https://eslint.vuejs.org/rules/#available-rules
     'plugin:vue/essential' // Priority A: Essential (Error Prevention)
     // 'plugin:vue/strongly-recommended' // Priority B: Strongly Recommended (Improving Readability)
     // 'plugin:vue/recommended' // Priority C: Recommended (Minimizing Arbitrary Choices and Cognitive Overhead)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Link fix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
Recently the link for available rules in `eslint-plugin-vue`'s documentation is also changed along with some other changes in https://github.com/quasarframework/quasar-starter-kit/commit/6897d3d8c85d61f8f1ceba195f1207059746eb3a. https://vuejs.github.io/eslint-plugin-vue is outdated, this can be seen by checking the `Last Updated` date for every page can be seen in the bottom right of every page. This PR contains a change to update the link.