### PR TITLE
chore(eslint): Change eslint `globals` deprecated syntax

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -34,12 +34,12 @@ module.exports = {
   ],
 
   globals: {
-    'ga': true, // Google Analytics
-    'cordova': true,
-    '__statics': true,
-    'process': true,
-    'Capacitor': true,
-    'chrome': true
+    'ga': writable, // Google Analytics
+    'cordova': writable,
+    '__statics': writable,
+    'process': writable,
+    'Capacitor': writable,
+    'chrome': writable
   },
 
   // add your custom rules here


### PR DESCRIPTION
Use of `true` in eslint `globals` configuration is deprecated. see https://eslint.org/docs/user-guide/configuring#specifying-globals
