### PR TITLE
fix(lint): disable vetur formatting for all eslint styles to avoid conflicts

### DIFF
--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   {{#preset.lint}}
   "vetur.validation.template": false,
-  {{#if_eq lintConfig "prettier"}}"vetur.format.enable": false,{{/if_eq}}
+  "vetur.format.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "vue"],
   {{/preset.lint}}
   {{#preset.typescript}}"typescript.tsdk": "node_modules/typescript/lib",{{/preset.typescript}}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Vetur uses Prettier to format Vue files by default.
It was already disabled for Prettier style because its version lagged behind the current one and was less efficient than Prettier own VSCode extension.

Vetur Prettier formatting is giving formatter/linter conflicts with AirBnB and Default styles mostly around quotes, so I disabled it altogether.
AirBnB and Default users are left without a default formatter, but at least they won't have conflicts.

The other option is to provide Prettier configuration to solve problems which arise when you don't use Prettier, which is pretty confusing and I wouldn't do