### PR TITLE
refactor(linting): remove eslint-loader for TS projects

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -25,7 +25,9 @@
     {{#preset.lint}}
     "babel-eslint": "^10.0.1",
     "eslint": "^6.8.0",
+    {{#unless preset.typescript}}
     "eslint-loader": "^3.0.3",
+    {{/unless}}
     "eslint-plugin-vue": "^6.1.2",
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^14.1.0",

--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -19,7 +19,7 @@
 const { configure } = require('quasar/wrappers');
 {{/preset.typescript}}
 
-module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function ({{#preset.lint}}{{#preset.typescript}}ctx{{else}}/* ctx */{{/preset.typescript}}{{else}}/* ctx */{{/preset.lint}}) {
+module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function (/* ctx */) {
   return {
     // https://quasar.dev/quasar-cli/supporting-ts
     supportTS: {{#if preset.typescript}}{{#if preset.lint}}{
@@ -84,22 +84,17 @@ module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function 
       // extractCSS: false,
 
       // https://quasar.dev/quasar-cli/handling-webpack
-      extendWebpack (cfg) {
-        {{#preset.lint}}
-        {{#preset.typescript}}
-          // linting is slow in TS projects, we execute it only for production builds
-        if (ctx.prod) {
-        {{/preset.typescript}}cfg.module.rules.push({
+      {{#if preset.typescript}}extendWebpack (/* cfg */) {
+        // Add here your webpack customizations
+      },{{else}}extendWebpack (cfg) {
+        {{#preset.lint}}cfg.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,
           loader: 'eslint-loader',
           exclude: /node_modules/
         })
-        {{#preset.typescript}}
-        }
-        {{/preset.typescript}}
         {{/preset.lint}}
-      },
+      },{{/if}}
     },
 
     // Full list of options: https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I noticed some time ago that eslint-loader wasn't actually needed for TS projects as fork-ts-checker can manage linting while checking for type correctness, speeding up the process too. For some reason, `eslint-loader` wasn't even linting Vue TS parts.

Notice that `eslint-loader` will soon be deprecated and must be switched with its plugin twin
https://github.com/webpack-contrib/eslint-loader/issues/337
https://github.com/webpack-contrib/eslint-webpack-plugin#about-plugin