### PR TITLE
fix(ts): :bug: remove trailing comma in tsconfig.json

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "."{{#if_eq typescriptConfig "class"}},
     "experimentalDecorators": true{{/if_eq}}{{#if preset.ie}},
-    "target": "es5",{{/if}}
+    "target": "es5"{{/if}}
   }
 }


### PR DESCRIPTION
As discussed in [quasar-testing/pull/117](https://github.com/quasarframework/quasar-testing/pull/117#issuecomment-688511042)
When installing `@quasar/testing-unit-jest` with Typescript support it attempts to modify the `tsconfig.json` but a parsing error occurs.
Removing this trailing comma by default will help ensure new Quasar projects based on the starter kit will not experience the same error.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
