### PR TITLE
feat(ts): support TS projects creation

### DIFF
--- a/template/.eslintignore
+++ b/template/.eslintignore
@@ -4,4 +4,5 @@
 /src-cordova
 /.quasar
 /node_modules
+.eslintrc.js
 {{#preset.typescript}}{{#preset.lint}}/src-ssr{{/preset.lint}}{{/preset.typescript}}

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -117,6 +117,7 @@ module.exports = {
     {{/if_eq}}
     {{#if_eq lintConfig "airbnb"}}
     'no-param-reassign': 'off',
+    'no-void': 'off',
 
     'import/first': 'off',
     'import/named': 'error',

--- a/template/package.json
+++ b/template/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     {{#if_eq typescriptConfig "class"}}
-    "vue-class-component": "^7.2.2",
-    "vue-property-decorator": "^8.3.0",
+    "vue-class-component": "^8.0.0-rc.1",
     {{/if_eq}}
     {{#preset.axios}}"axios": "^0.18.1",{{/preset.axios}}
     {{#preset.i18n}}"vue-i18n": "^9.0.0-beta.0",{{/preset.i18n}}
@@ -25,7 +24,9 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^7.14.0",
     "eslint-plugin-vue": "^7.0.0",
+    {{#unless preset.typescript}}
     "eslint-webpack-plugin": "^2.4.0",
+    {{/unless}}
     {{#if_eq lintConfig "standard"}}
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.19.1",
@@ -37,13 +38,13 @@
     "eslint-plugin-import": "^2.20.1",
     {{/if_eq}}
     {{#if_eq lintConfig "prettier"}}
-    "eslint-config-prettier": "^6.9.0",
+    "eslint-config-prettier": "^6.15.0",
     {{/if_eq}}
     {{/preset.lint}}
     {{#preset.typescript}}
     {{#preset.lint}}
-    "@typescript-eslint/eslint-plugin": "^3.3.0",
-    "@typescript-eslint/parser": "^3.3.0",
+    "@typescript-eslint/eslint-plugin": "^4.9.0",
+    "@typescript-eslint/parser": "^4.9.0",
     {{/preset.lint}}
     "@types/node": "^10.17.15",
     {{/preset.typescript}}

--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -8,25 +8,27 @@
 
 {{#preset.lint}}
 /* eslint-env node */
+{{#preset.typescript}}
+/* eslint-disable @typescript-eslint/no-var-requires */
+{{else}}
 const ESLintPlugin = require('eslint-webpack-plugin')
+{{/preset.typescript}}
 {{#if_eq lintConfig "airbnb"}}
 /* eslint func-names: 0 */
 /* eslint global-require: 0 */
 {{/if_eq}}
 {{/preset.lint}}
-{{#preset.typescript}}
-/* eslint-disable @typescript-eslint/no-var-requires */
-{{/preset.typescript}}
-{{#preset.typescript}}
 const { configure } = require('quasar/wrappers');
-{{/preset.typescript}}
 
-module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function ({{#preset.lint}}{{#preset.typescript}}ctx{{else}}/* ctx */{{/preset.typescript}}{{else}}/* ctx */{{/preset.lint}}) {
+module.exports = configure(function (/* ctx */) {
   return {
     // https://quasar.dev/quasar-cli/supporting-ts
     supportTS: {{#if preset.typescript}}{{#if preset.lint}}{
       tsCheckerConfig: {
-        eslint: true
+        eslint: {
+          enabled: true,
+          files: './src/**/*.{ts,tsx,js,jsx,vue}',
+        },
       }
     }{{else}}true{{/if}}{{else}}false{{/if}},
 
@@ -86,21 +88,19 @@ module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function 
 
       // https://quasar.dev/quasar-cli/handling-webpack
       // "chain" is a webpack-chain object https://github.com/neutrinojs/webpack-chain
-      chainWebpack (chain) {
-        {{#preset.lint}}
-        {{#preset.typescript}}
-          // linting is slow in TS projects, we execute it only for production builds
-        if (ctx.prod) {
-        {{/preset.typescript}}chain.plugin('eslint-webpack-plugin')
-        .use(ESLintPlugin, [{
-          extensions: [ 'js', 'vue' ],
-          exclude: 'node_modules'
-        }])
-        {{#preset.typescript}}
-        }
-        {{/preset.typescript}}
-        {{/preset.lint}}
+      {{#preset.typescript}}chainWebpack (/* chain */) {
+        // 
       },
+      {{else}}{{#preset.lint}}chainWebpack (chain) {
+        chain.plugin('eslint-webpack-plugin')
+          .use(ESLintPlugin, [{
+            extensions: [ 'js', 'vue' ],
+            exclude: 'node_modules'
+          }])
+        },
+      {{else}}chainWebpack (/* chain */) {
+        // 
+      },{{/preset.lint}}{{/preset.typescript}}
     },
 
     // Full list of options: https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer
@@ -220,4 +220,4 @@ module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function 
       }
     }
   }
-}{{#preset.typescript}});{{/preset.typescript}}
+});

--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -1,25 +1,12 @@
 <template>
   <router-view />
 </template>
-{{#if preset.typescript}}
-<script lang="ts">
-{{#if_eq typescriptConfig "composition"}}import { defineComponent } from '@vue/composition-api';
+<script{{#if preset.typescript}} lang="ts"{{/if}}>
+{{#if_eq typescriptConfig "class"}}import { Vue } from 'vue-class-component'
+
+export default class App extends Vue {}{{else}}import { defineComponent } from 'vue';
 
 export default defineComponent({
-  name: 'App',
-});{{/if_eq}}{{#if_eq typescriptConfig "class"}}import { Vue, Component } from 'vue-property-decorator';
-
-@Component
-export default class App extends Vue {}{{/if_eq}}{{#if_eq typescriptConfig "options"}}import Vue from 'vue';
-
-export default Vue.extend({
   name: 'App'
-});{{/if_eq}}
+}){{/if_eq}}
 </script>
-{{else}}
-<script>
-export default {
-  name: 'App'
-}
-</script>
-{{/if}}

--- a/template/src/boot/axios.js
+++ b/template/src/boot/axios.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
+import { boot } from 'quasar/wrappers';
 
-export default ({ app }) => {
+export default boot(({ app }) => {
   app.config.globalProperties.$axios = axios
-}
+})

--- a/template/src/boot/axios.ts
+++ b/template/src/boot/axios.ts
@@ -1,13 +1,12 @@
 import axios, { AxiosInstance } from 'axios';
 import { boot } from 'quasar/wrappers';
 
-declare module 'vue/types/vue' {
-  interface Vue {
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
     $axios: AxiosInstance;
   }
 }
 
-export default boot(({ Vue }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  Vue.prototype.$axios = axios;
+export default boot(({ app }) => {
+  app.config.globalProperties.$axios = axios;
 });

--- a/template/src/boot/i18n.js
+++ b/template/src/boot/i18n.js
@@ -1,3 +1,4 @@
+import { boot } from 'quasar/wrappers';
 import { createI18n } from 'vue-i18n'
 import messages from 'src/i18n'
 
@@ -6,9 +7,9 @@ const i18n = createI18n({
   messages
 })
 
-export default ({ app }) => {
+export default boot(({ app }) => {
   // Set i18n instance on app
   app.use(i18n)
-}
+})
 
 export { i18n }

--- a/template/src/boot/i18n.ts
+++ b/template/src/boot/i18n.ts
@@ -1,23 +1,15 @@
 import { boot } from 'quasar/wrappers';
+import { createI18n } from 'vue-i18n';
 import messages from 'src/i18n';
-import Vue from 'vue';
-import VueI18n from 'vue-i18n';
 
-declare module 'vue/types/vue' {
-  interface Vue {
-    i18n: VueI18n;
-  }
-}
-
-Vue.use(VueI18n);
-
-export const i18n = new VueI18n({
-  locale: "en-us",
-  fallbackLocale: "en-us",
-  messages
+const i18n = createI18n({
+  locale: 'en-us',
+  messages,
 });
 
 export default boot(({ app }) => {
   // Set i18n instance on app
-  app.i18n = i18n;
+  app.use(i18n);
 });
+
+export { i18n };

--- a/template/src/components/ClassComponent.vue
+++ b/template/src/components/ClassComponent.vue
@@ -13,24 +13,25 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Todo, Meta } from './models';
+import { Vue, prop } from 'vue-class-component'
+import { Todo, Meta } from './models'
 
-@Component
-export default class ClassComponent extends Vue {
-  @Prop({ type: String, required: true }) readonly title!: string;
-  @Prop({ type: Array, default: () => [] }) readonly todos!: Todo[];
-  @Prop({ type: Object, required: true }) readonly meta!: Meta;
-  @Prop(Boolean) readonly active!: boolean;
+class Props {
+  readonly title!: string;
+  readonly todos = prop<Todo[]>({ default: () => [] });
+  readonly meta!: Meta;
+  readonly active!: boolean;
+}
 
+export default class ClassComponent extends Vue.with(Props) {
   clickCount = 0;
 
-  increment() {
-    this.clickCount += 1;
+  increment () {
+    this.clickCount += 1
   }
 
-  get todoCount() {
-    return this.todos.length;
+  get todoCount () {
+    return this.todos.length
   }
 }
 </script>

--- a/template/src/components/CompositionComponent.vue
+++ b/template/src/components/CompositionComponent.vue
@@ -14,8 +14,13 @@
 
 <script lang="ts">
 import {
-  defineComponent, PropType, computed, ref, toRef, Ref,
-} from '@vue/composition-api';
+  defineComponent,
+  PropType,
+  computed,
+  ref,
+  toRef,
+  Ref,
+} from 'vue';
 import { Todo, Meta } from './models';
 
 function useClickCount() {
@@ -41,11 +46,11 @@ export default defineComponent({
       required: true
     },
     todos: {
-      type: (Array as unknown) as PropType<Todo[]>,
+      type: Array as PropType<Todo[]>,
       default: () => []
     },
     meta: {
-      type: (Object as unknown) as PropType<Meta>,
+      type: Object as PropType<Meta>,
       required: true
     },
     active: {

--- a/template/src/components/EssentialLink.vue
+++ b/template/src/components/EssentialLink.vue
@@ -21,9 +21,18 @@
   </q-item>
 </template>
 
-{{#if preset.typescript}}
-<script lang="ts">
-{{#if_eq typescriptConfig "composition"}}import { defineComponent } from '@vue/composition-api';
+<script{{#preset.typescript}} lang="ts"{{/preset.typescript}}>
+{{#if_eq typescriptConfig "class"}}import { Vue, prop, Options } from 'vue-class-component';
+
+class Props {
+  readonly title!: string;
+  readonly caption = prop({ default: '' });
+  readonly link = prop({ default: '#' });
+  readonly icon = prop({ default: '' });
+}
+
+@Options({})
+export default class EssentialLink extends Vue.with(Props) {}{{else}}import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'EssentialLink',
@@ -48,66 +57,5 @@ export default defineComponent({
       default: ''
     }
   }
-});{{/if_eq}}{{#if_eq typescriptConfig "class"}}import { Vue, Component, Prop } from 'vue-property-decorator';
-
-@Component
-export default class EssentialLink extends Vue {
-  @Prop({ type: String, required: true }) readonly title!: string;
-  @Prop({ type: String, default: '' }) readonly caption!: string;
-  @Prop({ type: String, default: '#' }) readonly link!: string;
-  @Prop({ type: String, default: ''}) readonly icon!: string;
-}{{/if_eq}}{{#if_eq typescriptConfig "options"}}import Vue from 'vue';
-
-export default Vue.extend({
-  name: 'EssentialLink',
-  props: {
-    title: {
-      type: String,
-      required: true
-    },
-
-    caption: {
-      type: String,
-      default: ''
-    },
-
-    link: {
-      type: String,
-      default: '#'
-    },
-
-    icon: {
-      type: String,
-      default: ''
-    }
-  }
-});{{/if_eq}}
+}){{/if_eq}}
 </script>
-{{else}}
-<script>
-export default {
-  name: 'EssentialLink',
-  props: {
-    title: {
-      type: String,
-      required: true
-    },
-
-    caption: {
-      type: String,
-      default: ''
-    },
-
-    link: {
-      type: String,
-      default: '#'
-    },
-
-    icon: {
-      type: String,
-      default: ''
-    }
-  }
-}
-</script>
-{{/if}}

--- a/template/src/components/OptionsComponent.vue
+++ b/template/src/components/OptionsComponent.vue
@@ -13,10 +13,10 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { Todo, Meta } from './models';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'OptionsComponent',
   props: {
     title: {
@@ -24,11 +24,11 @@ export default Vue.extend({
       required: true
     },
     todos: {
-      type: (Array as unknown) as PropType<Todo[]>,
+      type: Array as PropType<Todo[]>,
       default: () => [] as Todo[]
     },
     meta: {
-      type: (Object as unknown) as PropType<Meta>,
+      type: Object as PropType<Meta>,
       required: true
     },
     active: {

--- a/template/src/layouts/MainLayout.vue
+++ b/template/src/layouts/MainLayout.vue
@@ -47,7 +47,7 @@
   </q-layout>
 </template>
 
-<script{{#if preset.typescript}} lang="ts"{{/if}}>
+<script{{#preset.typescript}} lang="ts"{{/preset.typescript}}>
 import EssentialLink from 'components/EssentialLink.vue'
 
 const linksList = [
@@ -95,48 +95,41 @@ const linksList = [
   }
 ];
 
-{{#if preset.typescript}}
-{{#if_eq typescriptConfig "composition"}}import { defineComponent, ref } from '@vue/composition-api';
+{{#if_eq typescriptConfig "class"}}import { Vue, Options } from 'vue-class-component'
 
-export default defineComponent({
-  name: 'MainLayout',
-  components: { EssentialLink },
-  setup() {
-    const leftDrawerOpen = ref(false);
-
-    return {leftDrawerOpen, essentialLinks: linksList}
-  }
-});{{/if_eq}}{{#if_eq typescriptConfig "class"}}import { Vue, Component } from 'vue-property-decorator';
-
-@Component({
+@Options({
   components: { EssentialLink }
 })
 export default class MainLayout extends Vue {
   leftDrawerOpen = false;
   essentialLinks = linksList;
-}{{/if_eq}}{{#if_eq typescriptConfig "options"}}import Vue from 'vue';
-
-export default Vue.extend({
-  name: 'MainLayout',
-  components: { EssentialLink },
-  data() {
-    return {
-      leftDrawerOpen: false,
-      essentialLinks: linksList
-    }
+  toggleLeftDrawer () {
+    this.leftDrawerOpen = !this.leftDrawerOpen
   }
-});{{/if_eq}}
+}
 {{else}}
-import { ref } from 'vue'
+import { defineComponent{{#unless_eq typescriptConfig "options"}}, ref{{/unless_eq}} } from 'vue'
 
-export default {
+export default defineComponent({
   name: 'MainLayout',
 
   components: {
     EssentialLink
   },
 
-  setup () {
+  {{#if_eq typescriptConfig "options"}}data() {
+    return {
+      leftDrawerOpen: false,
+      essentialLinks: linksList
+    }
+  },
+
+  methods: {
+    toggleLeftDrawer () {
+      this.leftDrawerOpen = !this.leftDrawerOpen
+    }
+  }
+  {{else}}setup () {
     const leftDrawerOpen = ref(false)
 
     return {
@@ -147,6 +140,7 @@ export default {
       }
     }
   }
-}
-{{/if}}
+  {{/if_eq}}
+})
+{{/if_eq}}
 </script>

--- a/template/src/pages/Error404.vue
+++ b/template/src/pages/Error404.vue
@@ -22,25 +22,12 @@
   </div>
 </template>
 
-{{#if preset.typescript}}
-<script lang="ts">
-{{#if_eq typescriptConfig "composition"}}import { defineComponent } from '@vue/composition-api';
+<script{{#preset.typescript}} lang="ts"{{/preset.typescript}}>
+{{#if_eq typescriptConfig "class"}}import { Vue } from 'vue-class-component'
+
+export default class Error404 extends Vue {}{{else}}import { defineComponent } from 'vue'
 
 export default defineComponent({
-  name: 'Error404',
-});{{/if_eq}}{{#if_eq typescriptConfig "class"}}import { Vue, Component } from 'vue-property-decorator';
-
-@Component
-export default class Error404 extends Vue {}{{/if_eq}}{{#if_eq typescriptConfig "options"}}import Vue from 'vue';
-
-export default Vue.extend({
   name: 'Error404'
-});{{/if_eq}}
+}){{/if_eq}}
 </script>
-{{else}}
-<script>
-export default {
-  name: 'Error404'
-}
-</script>
-{{/if}}

--- a/template/src/pages/Index.vue
+++ b/template/src/pages/Index.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { Todo, Meta } from 'components/models';
 {{#if_eq typescriptConfig "composition"}}import ExampleComponent from 'components/CompositionComponent.vue';
-import { defineComponent, ref } from '@vue/composition-api';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'PageIndex',
@@ -47,9 +47,9 @@ export default defineComponent({
     return { todos, meta };
   }
 });{{/if_eq}}{{#if_eq typescriptConfig "class"}}import ExampleComponent from 'components/ClassComponent.vue';
-import { Vue, Component } from 'vue-property-decorator';
+import { Vue, Options } from 'vue-class-component'
 
-@Component({
+@Options({
   components: { ExampleComponent }
 })
 export default class PageIndex extends Vue {
@@ -79,9 +79,9 @@ export default class PageIndex extends Vue {
     totalCount: 1200
   };
 };{{/if_eq}}{{#if_eq typescriptConfig "options"}}import ExampleComponent from 'components/OptionsComponent.vue';
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PageIndex',
   components: { ExampleComponent },
   data() {
@@ -125,8 +125,10 @@ export default Vue.extend({
 </template>
 
 <script>
-export default {
+import { defineComponent } from 'vue';
+
+export default defineComponent({
   name: 'PageIndex'
-}
+})
 </script>
 {{/if}}

--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -1,5 +1,5 @@
+import { route } from 'quasar/wrappers';
 import { createRouter, createMemoryHistory, createWebHistory, createWebHashHistory } from 'vue-router'
-
 import routes from './routes'
 
 /*
@@ -11,13 +11,13 @@ import routes from './routes'
  * with the Router instance.
  */
 
-export default function (/* { store, ssrContext } */) {
+export default route(function (/* { store, ssrContext } */) {
   const createHistory = process.env.MODE === 'ssr'
     ? createMemoryHistory
     : process.env.VUE_ROUTER_MODE === 'history' ? createWebHistory : createWebHashHistory
 
   const Router = createRouter({
-    scrollBehavior: () => ({ x: 0, y: 0 }),
+    scrollBehavior: () => ({ left: 0, top: 0 }),
     routes,
 
     // Leave this as is and make changes in quasar.conf.js instead!
@@ -27,4 +27,4 @@ export default function (/* { store, ssrContext } */) {
   })
 
   return Router
-}
+})

--- a/template/src/router/index.ts
+++ b/template/src/router/index.ts
@@ -1,27 +1,41 @@
 import { route } from 'quasar/wrappers';
-import VueRouter from 'vue-router';
-{{#preset.vuex}}import { Store } from "vuex";
-import { StateInterface } from '../store';
+import {
+  createMemoryHistory,
+  createRouter,
+  createWebHashHistory,
+  createWebHistory,
+} from 'vue-router';
+{{#preset.vuex}}import { StateInterface } from '../store';
 {{/preset.vuex}}import routes from './routes';
 
 /*
  * If not building with SSR mode, you can
- * directly export the Router instantiation
+ * directly export the Router instantiation;
+ *
+ * The function below can be async too; either use
+ * async/await or return a Promise which resolves
+ * with the Router instance.
  */
 
-export default route{{#preset.vuex}}<Store<StateInterface>>{{/preset.vuex}}(function ({ Vue }) {
-  Vue.use(VueRouter);
+export default route{{#preset.vuex}}<StateInterface>{{/preset.vuex}}(function (/* { store, ssrContext } */) {
+  const createHistory =
+    process.env.MODE === 'ssr'
+      ? createMemoryHistory
+      : process.env.VUE_ROUTER_MODE === 'history'
+      ? createWebHistory
+      : createWebHashHistory;
 
-  const Router = new VueRouter({
-    scrollBehavior: () => ({ x: 0, y: 0 }),
+  const Router = createRouter({
+    scrollBehavior: () => ({ left: 0, top: 0 }),
     routes,
 
-    // Leave these as is and change from quasar.conf.js instead!
+    // Leave this as is and make changes in quasar.conf.js instead!
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
-    mode: process.env.VUE_ROUTER_MODE,
-    base: process.env.VUE_ROUTER_BASE
+    history: createHistory(
+      process.env.MODE === 'ssr' ? void 0 : process.env.VUE_ROUTER_BASE
+    ),
   });
 
   return Router;
-})
+});

--- a/template/src/router/routes.ts
+++ b/template/src/router/routes.ts
@@ -1,20 +1,18 @@
-import { RouteConfig } from 'vue-router';
+import { RouteRecordRaw } from 'vue-router';
 
-const routes: RouteConfig[] = [
+const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),
-    children: [
-      { path: '', component: () => import('pages/Index.vue') }
-    ]
+    children: [{ path: '', component: () => import('pages/Index.vue') }],
   },
 
   // Always leave this as last one,
   // but you can also remove it
   {
     path: '/:catchAll(.*)*',
-    component: () => import('pages/Error404.vue')
-  }
+    component: () => import('pages/Error404.vue'),
+  },
 ];
 
 export default routes;

--- a/template/src/store/index.js
+++ b/template/src/store/index.js
@@ -1,3 +1,4 @@
+import { store } from 'quasar/wrappers';
 import { createStore } from 'vuex'
 
 // import example from './module-example'
@@ -11,7 +12,7 @@ import { createStore } from 'vuex'
  * with the Store instance.
  */
 
-export default function (/* { ssrContext } */) {
+export default store(function (/* { ssrContext } */) {
   const Store = createStore({
     modules: {
       // example
@@ -23,4 +24,4 @@ export default function (/* { ssrContext } */) {
   })
 
   return Store
-}
+})

--- a/template/src/store/index.ts
+++ b/template/src/store/index.ts
@@ -1,12 +1,16 @@
 import { store } from 'quasar/wrappers';
-import Vuex from 'vuex';
+import { createStore } from 'vuex';
 
-// import example from './module-example';
+// import example from './module-example'
 // import { ExampleStateInterface } from './module-example/state';
 
 /*
  * If not building with SSR mode, you can
- * directly export the Store instantiation
+ * directly export the Store instantiation;
+ *
+ * The function below can be async too; either use
+ * async/await or return a Promise which resolves
+ * with the Store instance.
  */
 
 export interface StateInterface {
@@ -16,17 +20,15 @@ export interface StateInterface {
   example: unknown;
 }
 
-export default store(function ({ Vue }) {
-  Vue.use(Vuex);
-
-  const Store = new Vuex.Store<StateInterface>({
+export default store(function (/* { ssrContext } */) {
+  const Store = createStore<StateInterface>({
     modules: {
       // example
     },
 
     // enable strict mode (adds overhead!)
-    // for dev mode only
-    strict: !!process.env.DEBUGGING
+    // for dev mode and --debug builds only
+    strict: !!process.env.DEBUGGING,
   });
 
   return Store;

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@quasar/app/tsconfig-preset",
   "compilerOptions": {
     "baseUrl": "."{{#if_eq typescriptConfig "class"}},
-    "experimentalDecorators": true{{/if_eq}}
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true{{/if_eq}}
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Blocked by:
- https://github.com/quasarframework/quasar/pull/8139: Quasar typings updates compatible with Vue3
- https://github.com/quasarframework/quasar/pull/7989: fork-ts-checker version (should be updated to v6 in that branch), and removal of buggy v4-v5 options management implementation

Good news:
- starter kit with TS option compiles without errors with all of the APIs
- Composition API both for JS and TS is exactly the same in many components, as most of the types are inferred. This means TS migrations will be easy in many cases
- Since fork-ts-checker manage linting for TS projects, I could remove `eslint-webpack-plugin` dependency for them
- I added quasar wrappers to JS files too, to give everyone params autocomplete

Bad news:
- it needs the updated fork-ts-checker (at least v5, better if we update directly to v6) from the TS integration PR, which is still on hold, or manually updating only that dependency on q/app
- Class API (`vue-class-component` package) porting to Vue3 still isn't finished and there are no official docs on its usage. In case of `vue-property-decorator`, it even hasn't been started, as the maintainer himself actually believe Composition API is superior... I removed `vue-property-decorator` library and refactored everything to use the updated `vue-class-component` only.
- The dreaded auto-import error with Class API came back, probably due to internal changes of `vue-class-component` package. I don't have time right now to follow that track unfortunately