### PR TITLE
fix: template needs to be updated for framework.lang = 'en-US'

### DIFF
--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -113,7 +113,7 @@ module.exports = configure(function (/* ctx */) {
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework
     framework: {
       iconSet: 'material-icons', // Quasar icon set
-      lang: 'en-us', // Quasar language pack
+      lang: 'en-US', // Quasar language pack
       config: {},
 
       // For special cases outside of where the auto-import stategy can have an impact


### PR DESCRIPTION
This was missed in previous commits: https://github.com/quasarframework/quasar-starter-kit/compare/a4487d40ee02...c5964012c011