### PR TITLE
Add jsDoc annotations to quasar.conf parameters

### DIFF
--- a/template/quasar.conf.js
+++ b/template/quasar.conf.js
@@ -19,6 +19,11 @@
 const { configure } = require('quasar/wrappers');
 {{/preset.typescript}}
 
+/**
+ *
+ * @param {QuasarContext} ctx
+ * @return {QuasarConf}
+ */
 module.exports = {{#preset.typescript}}configure({{/preset.typescript}}function ({{#preset.lint}}{{#preset.typescript}}ctx{{else}}/* ctx */{{/preset.typescript}}{{else}}/* ctx */{{/preset.lint}}) {
   return {
     // https://quasar.dev/quasar-cli/supporting-ts


### PR DESCRIPTION
This will enable code inspections and autocomplete in editors that can pick it up for users that don't use typescript.

cc @IlCallo to make sure this doesn't break typescript in some unexpected way. I don't use typescript in Quasar, so I can't tell.