### PR TITLE
Fix(components): Add v-if in EssentialLink.vue.

### DIFF
--- a/template/src/components/EssentialLink.vue
+++ b/template/src/components/EssentialLink.vue
@@ -14,7 +14,10 @@
 
     <q-item-section>
       <q-item-label>\{{ title }}</q-item-label>
-      <q-item-label caption>
+      <q-item-label
+        v-if="caption"
+        caption
+      >
         \{{ caption }}
       </q-item-label>
     </q-item-section>


### PR DESCRIPTION
Since the default value for the `caption` prop is an empty string, we
need a check before its rendering.

I tried to add a new item in the `linkList` in `MainLayout.vue` without a `caption` prop, and got the following error in ssr mode:
```
[Vue warn]: Hydration children mismatch in <div>: server rendered element contains fewer child nodes than client vdom. 
  at <QItemLabel caption="" > 
  at <QItemSection> 
  at <QItem clickable="" tag="a" target="_blank"  ... > 
  at <EssentialLink key="About" title="About" link="about" > 
  at <QList> 
  at <QDrawer modelValue=false onUpdate:modelValue=fn show-if-above=""  ... > 
  at <QLayout view="lHh Lpr lFf" > 
  at <MainLayout onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< undefined > > 
  at <RouterView> 
  at <App>
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
