### PR TITLE
feat: add git repo auto initialization

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -32,7 +32,6 @@ module.exports = {
     css: {
       type: 'list',
       message: 'Pick your CSS preprocessor:',
-      default: 'scss',
       choices: [
         {
           name: 'Sass with SCSS syntax',
@@ -149,6 +148,12 @@ module.exports = {
           short: 'no',
         }
       ]
+    },
+
+    autoInitializeGit: {
+      type: 'confirm',
+      message: 'Automatically initialize git repository and commit all files?',
+      default: true,
     }
   },
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,8 +1,17 @@
 const path = require('path')
 const fs = require('fs')
-const spawn = require('child_process').spawn
+const { spawn, execSync } = require('child_process')
 
-const lintStyles = ['standard', 'airbnb', 'prettier']
+const lintStyles = ['prettier', 'standard', 'airbnb']
+
+/**
+ * Shows a colored string prefixed with a star char
+ * @param {Function} color Helper color function
+ * @param {string} messagge Message to display
+ */
+function starredLog(color, message) {
+  console.log(`\n\n ${color(`[*] ${message}`)}\n\n`)
+}
 
 /**
  * Sorts dependencies in package.json alphabetically.
@@ -36,9 +45,18 @@ function sortDependencies(data) {
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-function installDependencies(cwd, executable = 'npm', color) {
-  console.log(`\n\n ${color('[*] Installing project dependencies ...')}\n`)
-  return runCommand(executable, ['install'], { cwd })
+async function installDependencies(cwd, executable = 'npm', color) {
+  starredLog(color, 'Installing project dependencies...')
+
+  try {
+    await runCommand(executable, ['install'], { cwd })
+  } catch(e) {
+    console.log()
+    console.log(` ${executable} install FAILED... Possible temporary npm registry issues?`)
+    console.log(` Please try again later...`)
+    console.log()
+    process.exit(1)
+  }
 }
 
 /**
@@ -46,22 +64,23 @@ function installDependencies(cwd, executable = 'npm', color) {
  * @param {string} cwd Path of the created project directory
  * @param {object} data Data from questionnaire
  */
-function runLintFix(cwd, data, color) {
+async function runLintFix(cwd, data, color) {
   if (data.preset.lint && lintStyles.indexOf(data.lintConfig) !== -1) {
-    console.log(
-      `\n\n ${color(
-        '[*] Running eslint --fix to comply with chosen preset rules...'
-      )}\n\n`
-    )
+    starredLog(color, 'Running eslint --fix to comply with chosen preset rules...')
     const args =
       data.autoInstall === 'npm'
         ? ['run', 'lint', '--', '--fix']
         : ['run', 'lint', '--fix']
-    return runCommand(data.autoInstall, args, {
-      cwd,
-    })
+
+    try {
+      await runCommand(data.autoInstall, args, { cwd })
+    } catch(e) {
+      console.log()
+      console.log(` ${data.autoInstall} lint FAILED...`)
+      console.log(` Please try again later...`)
+      console.log()
+    }
   }
-  return Promise.resolve()
 }
 
 /**
@@ -75,6 +94,61 @@ function lintMsg(data) {
     lintStyles.indexOf(data.lintConfig) !== -1
     ? 'npm run lint -- --fix (or for yarn: yarn run lint --fix)\n  '
     : ''
+}
+
+/**
+ * Checks if Git is present in the system
+ */
+function hasGit() {
+  try {
+    execSync('git --version', { stdio: 'ignore' })
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+/**
+ * Checks if the project already have an initialized Git repo
+ * @param {string} cwd Path of the created project directory
+ */
+function hasProjectGit(cwd) {
+  try {
+    execSync('git status', { stdio: 'ignore', cwd })
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+/**
+ * Initialize a git repository into the project directory, if possible
+ * @param {string} cwd Path of the created project directory
+ * @param {object} chalk Console log color helpers
+ */
+async function initializeGit(cwd, { green, yellow }) {
+  starredLog(green, 'Initializing Git repository...')
+
+  if(!hasGit()) {
+    console.log(yellow(' Git is not present on the system, skipping...'))
+    return
+  }
+  
+  if(hasProjectGit(cwd)) {
+    console.log(yellow(' The project already have an initialized Git repository, skipping...'))
+    return
+  }
+
+  await runCommand('git', ['init'], { cwd })
+  await runCommand('git', ['add', '-A'], { cwd })
+  
+  try {
+    await runCommand('git', ['commit', '-m', 'init', '--no-verify'], { cwd, stdio: 'ignore' })
+  } catch (e) {
+    console.log()
+    console.log(yellow(' Skipped git commit because an error occurred, you will need to perform the initial commit yourself.'))
+    console.log()
+  }
 }
 
 /**
@@ -143,14 +217,11 @@ function runCommand(cmd, args, options) {
 
     spwan.on('exit', code => {
       if (code) {
-        console.log()
-        console.log(` ${cmd} install FAILED... Possible temporary npm registry issues?`)
-        console.log(` Please try again later...`)
-        console.log()
-        process.exit(1)
+        reject(code)
       }
-
-      resolve()
+      else {
+        resolve()
+      }
     })
   })
 }
@@ -166,26 +237,25 @@ function sortObject(object) {
   return sortedObject
 }
 
-module.exports.complete = function (data, { chalk }) {
-  const green = chalk.green
+module.exports.complete = async function (data, { chalk }) {
+  const { green } = chalk
 
   sortDependencies(data, green)
 
   const cwd = path.join(process.cwd(), data.inPlace ? '' : data.destDirName)
 
-  if (data.autoInstall) {
-    installDependencies(cwd, data.autoInstall, green)
-      .then(() => {
-        return runLintFix(cwd, data, green)
-      })
-      .then(() => {
-        printMessage(data, green)
-      })
-      .catch(e => {
-        console.log(chalk.red('Error:'), e)
-      })
+  try {
+    if (data.autoInstall) {
+      await installDependencies(cwd, data.autoInstall, green)
+      await runLintFix(cwd, data, green)
+    }
+    
+    if (data.autoInitializeGit) {
+      await initializeGit(cwd, chalk)
+    }
+  } catch(e) {
+    console.log(chalk.red('Error:'), e)
   }
-  else {
-    printMessage(data, chalk)
-  }
+    
+  printMessage(data, chalk)
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
We discussed this many times, I took inspiration from how Vue CLI does it, but simplified it greately since it was too complicated for our actual needs.

While I was at it, I also:
- refactored a bit to use async/await where possible
- provided more precise errors (failing linting would say the deps install failed)
- made failed linting not fatal