### PR TITLE
feat: explicitly reference quasar and @quasar/app typings

### DIFF
--- a/template/src/quasar.d.ts
+++ b/template/src/quasar.d.ts
@@ -1,0 +1,6 @@
+// Forces TS to apply `@quasar/app` augmentations of `quasar` package
+// Removing this would break `quasar/wrappers` imports as those typings are declared
+//  into `@quasar/app`
+// As a side effect, since `@quasar/app` reference `quasar` to augment it,
+//  this declaration also apply `quasar` own augmentations (eg. adds `$q` into Vue component context)
+/// <reference types="@quasar/app" />


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar-starter-kit/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Up until now we imported `@quasar/app` augmentations via [an import into `quasar` typings](https://github.com/quasarframework/quasar/blob/064c0f6854be87dd8ab78840badd750953dffd6b/ui/build/build.types.js#L268-L274), which would fail when executed into a Vue CLI project as `@quasar/app` isn't available there.
To avoid TS complaining on that use case we added a ts-ignore, which isn't the best way to handle it.

Additionally, we had to use the [tsconfig preset `types` field](https://github.com/quasarframework/quasar/blob/064c0f6854be87dd8ab78840badd750953dffd6b/app/tsconfig-preset.json#L24-L28) to include `quasar` typings even when not referenced directly into the code, which disabled `@types/*` automatic detection and generated a number of problems

By explicitly adding the import into a dedicated file, we can avoid many problems we hit up until now