### PR TITLE
fix: v1 project creation throws ESLint warning

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -121,6 +121,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     {{/if_eq}}
     'prefer-promise-reject-errors': 'off',
+    'func-names': 'off',
 
     {{#preset.typescript}}
     // TypeScript

--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -14,7 +14,6 @@ Vue.use(VueRouter)
  * with the Router instance.
  */
 
-// eslint-disable-next-line func-names
 export default function (/* { store, ssrContext } */) {
   const Router = new VueRouter({
     scrollBehavior: () => ({ x: 0, y: 0 }),

--- a/template/src/router/index.js
+++ b/template/src/router/index.js
@@ -14,6 +14,7 @@ Vue.use(VueRouter)
  * with the Router instance.
  */
 
+// eslint-disable-next-line func-names
 export default function (/* { store, ssrContext } */) {
   const Router = new VueRouter({
     scrollBehavior: () => ({ x: 0, y: 0 }),


### PR DESCRIPTION
Creation of new project using `Q1` throws a warning in console (see the attached image). 
I've added a linters `disable-next-line` to amend that particular issue.


![Screenshot 2021-11-05 at 12 58 38](https://user-images.githubusercontent.com/62475782/140507469-92550784-cce8-47a3-8c1e-448983504a3a.png)